### PR TITLE
Agregar link a perfil en github de usuario

### DIFF
--- a/components/user.js
+++ b/components/user.js
@@ -1,9 +1,15 @@
 export default function User({ username, color, boxSizes }) {
   return (
     <>
-      <div data-testid={username} className="user" key={username}>
+      <a
+        href={`https://github.com/${username}`}
+        data-testid={username}
+        className="user"
+        key={username}
+        title={`@${username}`}
+      >
         <span className="username">{username}</span>
-      </div>
+      </a>
       <style jsx>{`
         .user {
           background: linear-gradient(#${color} 100%, #${color} 100%),


### PR DESCRIPTION
Parecido a como ocurre actualmente con la foto del avatar, si el usuario agregado tiene perfil en github, al seleccionar la foto te redirige a su página 